### PR TITLE
Reject Promise when HTTP request for Task Solution Fails

### DIFF
--- a/src/AntiCaptcha.ts
+++ b/src/AntiCaptcha.ts
@@ -117,7 +117,7 @@ export class AntiCaptcha {
                 // If Error we reject
                 if (!response.ok || response.data.errorId !== 0) {
                     clearInterval(routine);
-                    reject(new Error(response.data.errorDescription));
+                    reject(new Error(response.data.hasOwnProperty('errorDescription') ? response.data.errorDescription : 'http request to get task result failed'));
                     return;
                 }
 


### PR DESCRIPTION
Got this error a little while ago

![image](https://user-images.githubusercontent.com/1587024/50536342-5aff0700-0b21-11e9-9b4e-c1a5c3bae674.png)

Traced it back to here

![image](https://user-images.githubusercontent.com/1587024/50536354-8681f180-0b21-11e9-9ed2-a70593a81cbb.png)

Seems like if the response is not ok, there won't be a data object, which will throw an error before you get to reject it the promise. 

My patch checks if `response.data.errorDescription` exists. If it does, it is used. If not, it uses a generic error message.