### PR TITLE
Additional typescript support, add getQueueStats

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 This library is a NodeJS wrapper that expose an modern API in order to exploit the https://anti-captcha.com/ service.
 
-Please keep in mind that this is a work in progress and it only support Proxyless Recaptcha breaker at the moment.
+Please keep in mind that this is a work in progress and it only supports certain tasks types. Pull requests welcome!
 
 
 ## Documentation
@@ -23,38 +23,59 @@ For the example, we will use the nice feature that are [ES7 Async Function](http
 
 **Caution** : Keep in mind that real people are working behind the network to break the hash. This can lead to some delay depending on the service charge's load, therefore you might require to set a greater timeout for your calls if you're using this through an REST API.
 
-```javascript
+```typescript
 // main.js
-import { AntiCaptcha } from "anticaptcha";
+import { AntiCaptcha,
+         AntiCaptchaError,
+         ErrorTypes,
+         INoCaptchaTaskProxyless,
+         INoCaptchaTaskProxylessResult,
+         QueueTypes,
+         TaskTypes } from "anticaptcha";
 
 // Registering the API Client.
 const AntiCaptchaAPI = new AntiCaptcha("<your_client_ID>"); // You can pass true as second argument to enable debug logs.
 
 const mainProcess = async () => {
-    // Checking the account balance before creating a task. This is a conveniance method.
-    if (await !AntiCaptchaAPI.isBalanceGreaterThan(10)) {
-        // You can dispatch a warning using mailer or do whatever.
-        console.warn("Take care, you're running low on money !")
-    }
+    try {
+      // Checking the account balance before creating a task. This is a conveniance method.
+      if (await !AntiCaptchaAPI.isBalanceGreaterThan(10)) {
+          // You can dispatch a warning using mailer or do whatever.
+          console.warn("Take care, you're running low on money !")
+      }
 
-    // Creating a task to resolve.
-    const taskId = await AntiCaptchaAPI.createTask(
-        "http://www.some-site.com", // The page where the captcha is
-        "7Lfh6tkSBBBBBBGN68s8fAVds_Fl-HP0xQGNq1DK", // The data-site-key value
-    )
+      // Get service stats
+      const stats = await this.getQueueStats(QueueTypes.RECAPTCHA_PROXYLESS);
 
-    // Waiting for resolution and do something
-    const response = await AntiCaptchaAPI.getTaskResult(taskId);
+      // Creating nocaptcha proxyless task
+      const taskId = await AntiCaptchaAPI.createTask<INoCaptchaTaskProxyless>({
+          type: TaskTypes.NOCAPTCHA_PROXYLESS,
+          websiteKey: "http://www.some-site.com",
+          websiteURL: "7Lfh6tkSBBBBBBGN68s8fAVds_Fl-HP0xQGNq1DK",
+      });
+
+      // Waiting for resolution and do something
+      const response = await AntiCaptchaAPI.getTaskResult<INoCaptchaTaskProxylessResult>(taskId);
+      
+      console.log(`Response Code: ${response.solution.gRecaptchaResponse}`);
+    } catch (e) {
+        if ( (e instanceof AntiCaptchaError ) && (e.code === ErrorCodes.ERROR_IP_BLOCKED ) ) {
+                // do something...
+            }
+        }
 }
 
 ```
 
-The response object looks like this, feel free to check Typescript definition file that are given. This will give you nice view of the object properties.
+When calling `createTask` or `getTaskResult` you'll need to specify the task type. Check the TypeScript definition file that are given. This will give you nice view of the object properties. The following tasks are currently supported (other types are defined at: https://anticaptcha.atlassian.net/wiki/spaces/API/pages/5079084/Captcha+Task+Types): 
+- `IImageToTextTask` (result type `IImageToTextTaskResult`)
+- `INoCaptchaTaskProxyless` (result type `INoCaptchaTaskProxylessResult`)
+- `IRecaptchaV3TaskProxyless` (result type `IRecaptchaV3TaskProxylessResult`)
 
 ```typescript
  {
     status: "ready" | "processing";
-    solution: { gRecaptchaResponse: string };
+    solution: T;
     cost: number;
     ip: string;
     createTime: number;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anticaptcha",
-  "version": "1.0.6",
+  "version": "2.0.0",
   "description": "A modern wrapper around AntiCaptcha API.",
   "author": "Andréas \"ScreamZ\" Hanss",
   "license": "MIT",

--- a/src/AntiCaptcha.ts
+++ b/src/AntiCaptcha.ts
@@ -1,6 +1,13 @@
 import { ApiResponse, ApisauceInstance, create } from "apisauce";
-import { TaskTypes } from "./enum";
-import { ICreateTaskResponse, IGetBalanceResponse, IGetTaskResultResponse } from "./interfaces";
+import { LanguagePoolTypes, QueueTypes, TaskStatus } from "./enum";
+import { AntiCaptchaError } from "./error";
+import { ICreateTaskRequest,
+        ICreateTaskResponse,
+        IGetBalanceResponse,
+        IGetQueueStatsResponse,
+        IGetTaskResultResponse,
+        INoCaptchaTaskProxyless,
+        INoCaptchaTaskProxylessResult} from "./interfaces";
 
 export class AntiCaptcha {
     private api: ApisauceInstance;
@@ -15,7 +22,7 @@ export class AntiCaptcha {
      */
     constructor(clientKey: string, debugMode = false) {
         this.api = create({
-            baseURL: "http://api.anti-captcha.com",
+            baseURL: "https://api.anti-captcha.com",
         });
         this.debug = debugMode;
 
@@ -30,10 +37,17 @@ export class AntiCaptcha {
     }
 
     /**
+     * Get queue stats
+     */
+    public async getQueueStats(queueType: QueueTypes): Promise<IGetQueueStatsResponse> {
+        const response = await this.api.post("getQueueStats", {
+            queueId: queueType,
+        }) as ApiResponse<IGetQueueStatsResponse>;
+        return response.data;
+    }
+
+    /**
      * Get the account balance.
-     *
-     * @returns {Promise<ApiResponse<any>>}
-     * @memberof AntiCaptcha
      */
     public async getBalance() {
         const response = await this.api.post("getBalance") as ApiResponse<IGetBalanceResponse>;
@@ -41,16 +55,13 @@ export class AntiCaptcha {
             return response.data.balance;
         }
 
-        throw new Error(response.data.errorDescription);
+        throw new AntiCaptchaError(response.data.errorCode, response.data.errorDescription);
     }
 
     /**
      * Helper method to check whether the account balance is greater than the given amount.
      *
      * @param {number} amount - The amount to compare.
-     *
-     * @returns {Promise<boolean>}
-     * @memberof AntiCaptcha
      */
     public async isBalanceGreaterThan(amount: number) {
         return await this.getBalance() > amount;
@@ -58,31 +69,24 @@ export class AntiCaptcha {
 
     /**
      * Dispatch a task creation to the service. This will return a taskId.
-     * Currently only Recaptcha proxyless is available.
      *
-     * @param {string} websiteURL - The URL where the captcha is defined.
+     * @param {string} task - Task to perform
      * @param {string} websiteKey - The value of the "data-site-key" attribute.
      * @param {string} languagePool - The language pool. Default to English if not provided.
      *
-     * @returns {Promise<number>}
      * @memberof AntiCaptcha
      */
-    public async createTask(websiteURL: string, websiteKey: string, languagePool: string = "en") {
+    public async createTask<T>( task: T,
+                                languagePool: LanguagePoolTypes = LanguagePoolTypes.ENGLISH) {
         const response = await this.api.post("createTask", {
             languagePool,
-            task: {
-                type: TaskTypes.RECAPTCHA_PROXYLESS,
-                websiteKey,
-                websiteURL,
-            },
+            task,
         }) as ApiResponse<ICreateTaskResponse>;
 
         if (response.ok && response.data.errorId === 0) {
-            if (this.debug) { console.log(`Task [ ${response.data.taskId} ] - Created`); }
-            return response.data.taskId;
+            throw new AntiCaptchaError(response.data.errorCode, response.data.errorDescription);
         }
-
-        throw new Error(response.data.errorDescription);
+        return response.data.taskId;
     }
 
     /**
@@ -92,12 +96,10 @@ export class AntiCaptcha {
      * @param {number} [retry=12] - The number of time the request must be tryed if worker is busy.
      * @param {number} [retryInterval=10000] - The amount of time before first and each try.
      *
-     * @returns {Promise<IGetTaskResultResponse>}
-     *
      * @see createTask
      * @memberof AntiCaptcha
      */
-    public async getTaskResult(taskId: number, retry: number = 12, retryInterval = 10000) {
+    public async getTaskResult<T>(taskId: number, retry: number = 12, retryInterval = 10000) {
         let retryCount = 0;
         return new Promise((resolve, reject) => {
             const routine = setInterval(async () => {
@@ -110,11 +112,16 @@ export class AntiCaptcha {
                 }
 
                 const response = await this.api
-                    .post("getTaskResult", { taskId }) as ApiResponse<IGetTaskResultResponse>;
+                    .post("getTaskResult", { taskId }) as ApiResponse<IGetTaskResultResponse<T>>;
 
                 retryCount++; // We update the timeout count
 
-                // If Error we reject
+                // API service failure
+                if (response.ok && response.data.errorId > 0) {
+                    reject(new AntiCaptchaError(response.data.errorCode, response.data.errorDescription));
+                }
+
+                // Generic failure
                 if (!response.ok || !response.data || response.data.errorId !== 0) {
                     clearInterval(routine);
                     reject(new Error(response.data && response.data.hasOwnProperty('errorDescription') ? response.data.errorDescription : 'http request to get task result failed'));
@@ -122,13 +129,13 @@ export class AntiCaptcha {
                 }
 
                 // If request is OK, we resolve
-                if (response.data.status === "ready") {
+                if (response.data.status === TaskStatus.READY) {
                     if (this.debug) { console.log(`Task [ ${taskId} ] - Hash found !`); }
                     clearInterval(routine);
                     resolve(response.data);
                     return;
                 }
             }, retryInterval);
-        }) as Promise<IGetTaskResultResponse>;
+        }) as Promise<IGetTaskResultResponse<T>>;
     }
 }

--- a/src/enum.ts
+++ b/src/enum.ts
@@ -1,6 +1,241 @@
 export enum TaskTypes {
-  RECAPTCHA_PROXYLESS = "NoCaptchaTaskProxyless",
-  RECAPTCHA_PROXY = "NoCaptchaTask",
+  NOCAPTCHA_PROXYLESS = "NoCaptchaTaskProxyless",
+  NOCAPTCHA = "NoCaptchaTask",
+  RECAPTCHA_PROXYLESS = "RecaptchaV3TaskProxyless",
   IMAGE_TO_TEXT = "ImageToTextTask",
   FUN_CAPTCHA = "FunCaptchaTask",
+}
+
+export enum QueueTypes {
+  IMAGE_TO_TEXT_ENGLISH = "1",
+  IMAGE_TO_TEXT_RUSSIAN = "2",
+  RECAPTCHA_NOCAPTCHA = "5",
+  RECAPTCHA_PROXYLESS = "6",
+  FUNCAPTCHA = "7",
+  FUNCAPTCHA_PROXYLESS = "10",
+}
+
+export enum LanguagePoolTypes {
+  ENGLISH = "en",
+  RUSSIAN = "ru",
+}
+
+export enum TaskStatus {
+  PROCESSING = "processing",
+  READY = "ready",
+}
+
+export enum RecaptchaWorkerScore {
+  LOW = 0.3,
+  MEDIUM = 0.5,
+  HIGH = 0.9,
+}
+
+export enum ImageNumericRequirements {
+  NO_REQUIREMENTS = 0,
+  ONLY_NUMBERS = 1,
+  LETTERS_ONLY = 2,
+}
+
+export enum ErrorCodes {
+  /**
+   * Account authorization key not found in the system
+   */
+  ERROR_KEY_DOES_NOT_EXIST = "1",
+  /**
+   * No idle captcha workers are available at the moment,
+   * please try a bit later or try increasing your maximum bid
+   *
+   * @url https://anti-captcha.com/panel/settings/recognition
+   */
+  ERROR_NO_SLOT_AVAILABLE = "2",
+  /**
+   * The size of the captcha you are uploading is less than 100 bytes.
+   */
+  ERROR_ZERO_CAPTCHA_FILESIZE = "3",
+  /**
+   * The size of the captcha you are uploading is more than 500,000 bytes.
+   */
+  ERROR_TOO_BIG_CAPTCHA_FILESIZE = "4",
+  /**
+   * Account has zeo or negative balance
+   */
+  ERROR_ZERO_BALANCE = "10",
+  /**
+   * Request with current account key is not allowed from your IP. Please refer to IP list section located
+   *
+   * @url https://anti-captcha.com/panel/settings/security
+   */
+  ERROR_IP_NOT_ALLOWED = "11",
+  /**
+   * Captcha could not be solved by 5 different workers
+   */
+  ERROR_CAPTCHA_UNSOLVABLE = "12",
+  /**
+   * 100% recognition feature did not work due to lack of amount of guess attempts
+   *
+   * @url https://anti-captcha.com/panel/settings/recognition
+   */
+  ERROR_BAD_DUPLICATES = "13",
+  /**
+   * Request to API made with method which does not exist
+   */
+  ERROR_NO_SUCH_METHOD = "14",
+  /**
+   * Could not determine captcha file type by its exif header or
+   * image type is not supported. The only allowed formats are JPG,
+   * GIF, PNG
+   */
+  ERROR_IMAGE_TYPE_NOT_SUPPORTED = "15",
+  /**
+   * Captcha you are requesting does not exist in your current
+   * captchas list or has been expired. Captchas are removed from
+   * API after 5 minutes after upload.
+   */
+  ERROR_NO_SUCH_CAPCHA_ID = "16",
+  /**
+   * comment" property is required for this request
+   */
+  ERROR_EMPTY_COMMENT = "20",
+  /**
+   * Your IP is blocked due to API inproper use.
+   *
+   * @url https://anti-captcha.com/panel/tools/ipsearch
+   */
+  ERROR_IP_BLOCKED = "21",
+  /**
+   * Task property is empty or not set in createTask method. Please refer to API v2 documentation.
+   *
+   * @url https://anticaptcha.atlassian.net/wiki/spaces/API/pages/5079073/createTask+%3A+captcha+task+creating
+   */
+  ERROR_TASK_ABSENT = "22",
+  /**
+   * Task type is not supported or inproperly printed. Please check \"type\" parameter in task object.
+   */
+  ERROR_TASK_NOT_SUPPORTED = "23",
+  /**
+   * Some of the required values for successive user emulation are missing.
+   */
+  ERROR_INCORRECT_SESSION_DATA = "24",
+  /**
+   * Could not connect to proxy related to the task, connection refused
+   */
+  ERROR_PROXY_CONNECT_REFUSED = "25",
+  /**
+   * Could not connect to proxy related to the task, connection timeout
+   */
+  ERROR_PROXY_CONNECT_TIMEOUT = "26",
+  /**
+   * Connection to proxy for task has timed out
+   */
+  ERROR_PROXY_READ_TIMEOUT = "27",
+  /**
+   * Proxy IP is banned by target service
+   */
+  ERROR_PROXY_BANNED = "28",
+  /**
+   * Task denied at proxy checking state. Proxy must be non-transparent to hide our server IP.
+   */
+  ERROR_PROXY_TRANSPARENT = "29",
+  /**
+   * Recaptcha task timeout, probably due to slow proxy server or Google server
+   */
+  ERROR_RECAPTCHA_TIMEOUT = "30",
+  /**
+   * Recaptcha server reported that site key is invalid
+   */
+  ERROR_RECAPTCHA_INVALID_SITEKEY = "31",
+  /**
+   * Recaptcha server reported that domain for this site key is invalid
+   */
+  ERROR_RECAPTCHA_INVALID_DOMAIN = "32",
+  /**
+   * Recaptcha server reported that browser user-agent is not compatible with their javascript
+   */
+  ERROR_RECAPTCHA_OLD_BROWSER = "33",
+  /**
+   * Captcha provider server reported that additional variable token has been expired. Please try again with new token.
+   */
+  ERROR_TOKEN_EXPIRED = "34",
+  /**
+   * Proxy does not support transfer of image data from Google servers
+   */
+  ERROR_PROXY_HAS_NO_IMAGE_SUPPORT = "35",
+  /**
+   * Proxy does not support long GET requests with length about 2000 bytes and does not support SSL connections
+   */
+  ERROR_PROXY_INCOMPATIBLE_HTTP_VERSION = "36",
+  /**
+   * Could not connect to Factory Server API within 5 seconds
+   */
+  ERROR_FACTORY_SERVER_API_CONNECTION_FAILED = "37",
+  /**
+   * Incorrect Factory Server JSON response, something is broken
+   */
+  ERROR_FACTORY_SERVER_BAD_JSON = "38",
+  /**
+   * Factory Server API did not send any errorId
+   */
+  ERROR_FACTORY_SERVER_ERRORID_MISSING = "39",
+  /**
+   * Factory Server API reported errorId != 0, check this error
+   */
+  ERROR_FACTORY_SERVER_ERRORID_NOT_ZERO = "40",
+  /**
+   * Some of the required property values are missing in Factory
+   * form specifications. Customer must send all required values.
+   */
+  ERROR_FACTORY_MISSING_PROPERTY = "41",
+  /**
+   * Expected other type of property value in Factory form structure. Customer must send specified value type.
+   */
+  ERROR_FACTORY_PROPERTY_INCORRECT_FORMAT = "42",
+  /**
+   * Factory control belong to another account, check your account key.
+   */
+  ERROR_FACTORY_ACCESS_DENIED = "43",
+  /**
+   * Factory Server general error code
+   */
+  ERROR_FACTORY_SERVER_OPERATION_FAILED = "44",
+  /**
+   * Factory Platform general error code.
+   */
+  ERROR_FACTORY_PLATFORM_OPERATION_FAILED = "45",
+  /**
+   * Factory task lifetime protocol broken during task workflow.
+   */
+  ERROR_FACTORY_PROTOCOL_BROKEN = "46",
+  /**
+   * Task not found or not available for this operation
+   */
+  ERROR_FACTORY_TASK_NOT_FOUND = "47",
+  /**
+   * Factory is sandboxed, creating tasks is possible only by Factory owner. Switch it to
+   * production mode to make it available for other customers.
+   */
+  ERROR_FACTORY_IS_SANDBOXED = "48",
+  /**
+   * Proxy login and password are incorrect
+   */
+  ERROR_PROXY_NOT_AUTHORISED = "49",
+  /**
+   * Customer did not enable Funcaptcha Proxyless tasks in Customers Area - API Settings.
+   * All customers must read terms, pass mini test and sign/accept the form before being
+   * able to use this feature.
+   *
+   * @url https://anti-captcha.com/clients/settings/apisetup
+   */
+  ERROR_FUNCAPTCHA_NOT_ALLOWED = "50",
+  /**
+   * Recaptcha was attempted to be solved as usual one, instead of invisible mode.
+   * Basically you don't need to do anything when this error occurs, just continue
+   * sending tasks with this domain. Our system will self-learn to solve recaptchas
+   * from this sitekey in invisible mode.
+   */
+  ERROR_INVISIBLE_RECAPTCHA = "51",
+  /**
+   * Could not load captcha provider widget in worker browser. Please try sending new task.
+   */
+  ERROR_FAILED_LOADING_WIDGET = "52",
 }

--- a/src/error.ts
+++ b/src/error.ts
@@ -1,0 +1,10 @@
+import { ErrorCodes } from "./enum";
+
+export class AntiCaptchaError extends Error {
+    public readonly code: ErrorCodes;
+
+    constructor(code: ErrorCodes, message: string) {
+        super(message);
+        this.code = code;
+    }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,14 @@
 export { AntiCaptcha } from "./AntiCaptcha";
-export { TaskTypes } from "./enum";
+export { TaskTypes,
+         QueueTypes,
+         LanguagePoolTypes,
+         TaskStatus,
+         RecaptchaWorkerScore,
+         ImageNumericRequirements,
+         ErrorCodes } from "./enum";
+export { INoCaptchaTaskProxyless,
+         INoCaptchaTaskProxylessResult,
+         IRecaptchaV3TaskProxyless,
+         IRecaptchaV3TaskProxylessResult,
+         IImageToTextTask,
+         IImageToTextTaskResult} from "./interfaces";

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,23 +1,219 @@
+import { ErrorCodes, ImageNumericRequirements, LanguagePoolTypes, RecaptchaWorkerScore, TaskStatus, TaskTypes} from "./enum";
+
 export interface IApiError {
   errorId: number;
-  errorCode: string;
+  errorCode: ErrorCodes;
   errorDescription: string;
+}
+
+export interface IGetQueueStatsResponse extends IApiError {
+  /**
+   * Amount of idle workers online, waiting for a task
+   */
+  waiting: number;
+  /**
+   * Queue load in percents
+   */
+  load: number;
+  /**
+   * Average task solution cost in USD
+   */
+  bid: string;
+  /**
+   * Average task solution speed in seconds
+   */
+  speed: number;
+  /**
+   * Total number of workers
+   */
+  total: number;
 }
 
 export interface IGetBalanceResponse extends IApiError {
   balance: number;
 }
 
+export interface ICreateTaskRequest<T> {
+  /**
+   * Sets workers pool language.
+   */
+  languagePool?: LanguagePoolTypes;
+  /**
+   * ID of your application from AppCenter,
+   * this is required to earn 10% from clients spendings which use your application.
+   * @url https://anti-captcha.com/panel/tools/appcenter#developer
+   */
+  softId?: string;
+  /**
+   * Task data
+   */
+  task: T;
+  /**
+   * Optional web address were will send result of captcha/factory task processing.
+   * Contents are sent by AJAX POST request and are similar to the contents of
+   * getTaskResult method.
+   * @url https://anticaptcha.atlassian.net/wiki/spaces/API/pages/5079103/getTaskResult+%3A+request+task+result
+   */
+  callbackUrl?: string;
+}
+
 export interface ICreateTaskResponse extends IApiError {
   taskId: number;
 }
 
-export interface IGetTaskResultResponse extends IApiError {
-  status: "ready" | "processing";
-  solution: { gRecaptchaResponse: string };
+export interface INoCaptchaTaskProxyless {
+  /**
+   * Must be set to NoCaptchaTaskProxyless
+   */
+  type: TaskTypes.NOCAPTCHA_PROXYLESS;
+  /**
+   * Address of target web page
+   */
+  websiteURL: string;
+  /**
+   * Recaptcha website key
+   * @example <div class="g-recaptcha" data-sitekey="THAT_ONE"></div>
+   */
+  websiteKey: string;
+  /**
+   * Secret token for previous version of Recaptcha (now deprecated). In
+   * most cases websites use newer version and this token is not required.
+   */
+  websiteSToken?: string;
+  /**
+   * Specify that Recaptcha is invisible. This will render an appropriate widget
+   * for our workers.
+   */
+  isInvisible?: boolean;
+}
+
+export interface INoCaptchaTaskProxylessResult {
+  /**
+   * Hash string which is required for interacting with submit form on target website.
+   */
+  gRecaptchaResponse: string;
+}
+
+export interface IRecaptchaV3TaskProxyless {
+  /**
+   * Must be set to RecaptchaV3TaskProxyless
+   */
+  type: TaskTypes.RECAPTCHA_PROXYLESS;
+  /**
+   * Address of target web page
+   */
+  websiteURL: string;
+  /**
+   * Recaptcha website key
+   * @example <div class="g-recaptcha" data-sitekey="THAT_ONE"></div>
+   */
+  websiteKey: string;
+  /**
+   * Filters a worker with corresponding score. Can be one of the following:
+   * 0.3
+   * 0.7
+   * 0.9
+   */
+  minScore: RecaptchaWorkerScore;
+  /**
+   * Widget action value. Website owner defines what user is doing on the page through this parameter.
+   * @example grecaptcha.execute('site_key', {action:'login_test'}).
+   */
+  pageAction: string;
+}
+export interface IRecaptchaV3TaskProxylessResult {
+  /**
+   * Hash string which is required for interacting with submit form on target website.
+   */
+  gRecaptchaResponse: string;
+}
+
+export interface IImageToTextTask {
+  /**
+   * Must be ImageToTextTask
+   */
+  type: TaskTypes.IMAGE_TO_TEXT;
+  /**
+   * File body encoded in base64. Make sure to send it without line breaks.
+   */
+  body: string;
+  /**
+   * false - no requirements
+   * true - worker must enter an answer with at least one "space"
+   */
+  phrase?: boolean;
+  /**
+   * false - no requirements
+   * true - worker will see a special mark telling that answer must be entered with case sensitivity.
+   */
+  case?: boolean;
+  /**
+   * 	0 - no requirements
+   * 1 - only number are allowed
+   * 2 - any letters are allowed except numbers
+   */
+  numeric?: ImageNumericRequirements;
+  /**
+   * false - no requirements
+   * true - worker will see a special mark telling that answer must be calculated
+   */
+  math?: boolean;
+  /**
+   * minimum length of the answer
+   */
+  minLength?: number;
+  /**
+   * maximum length of the answer
+   */
+  maxLength?: number;
+  /**
+   * Additional comment for workers like "enter letters in red color".
+   * Result is not guaranteed.
+   */
+  comment?: string;
+}
+
+export interface IImageToTextTaskResult {
+  /**
+   * Captcha answer
+   */
+  text: string;
+  /**
+   * Web address where captcha file can be downloaded. Available withing 48 hours after task creation.
+   */
+  url: string;
+}
+
+export interface IGetTaskResultRequest {
+  /**
+   * ID which was obtained in createTask method.
+   */
+  taskId: string;
+}
+export interface IGetTaskResultResponse<T> extends IApiError {
+  /**
+   * Task status.
+   */
+  status: TaskStatus;
+  /**
+   * Task result data. Different for each type of task.
+   */
+  solution: T;
+  /**
+   * Task cost in USD.
+   */
   cost: number;
+  /**
+   * IP from which the task was created.
+   */
   ip: string;
+  /**
+   * UNIX Timestamp of task creation.
+   */
   createTime: number;
+  /**
+   * UNIX Timestamp of task completion.
+   */
   endTime: number;
 
   /**


### PR DESCRIPTION
This includes several changes to better support typescript. I have updated version to `2.0.0` since the createTask / getTaskResult changes are not backwards compatible with `1.x`.

**1. Create task/ getTask result support multiple types**
Instead of creating a task like this:
```
const taskId = await AntiCaptchaAPI.createTask(
    "http://www.some-site.com", // The page where the captcha is
    "7Lfh6tkSBBBBBBGN68s8fAVds_Fl-HP0xQGNq1DK", // The data-site-key value
)

const response = await AntiCaptchaAPI.getTaskResult(taskId);
```

You can specify the type
```
// Creating nocaptcha proxyless task
const taskId = await AntiCaptchaAPI.createTask<INoCaptchaTaskProxyless>({
      type: TaskTypes.NOCAPTCHA_PROXYLESS,
      websiteKey: "http://www.some-site.com",
      websiteURL: "7Lfh6tkSBBBBBBGN68s8fAVds_Fl-HP0xQGNq1DK",
});

// Waiting for resolution and do something
const response = await AntiCaptchaAPI.getTaskResult<INoCaptchaTaskProxylessResult>(taskId);
```
**2. GetQueueStats**
Adds supports for `getQueueStats`. Available `queueTypes` are defined as an enum.

**3. Custom errors**
Added `AntiCaptchaError` error type. All the different error codes are defined in the `ErrorCodes` enum. For example you can now do this:

```
try {
    const response = await AntiCaptchaAPI.getTaskResult(taskId);
} catch(e) {
    if ( (e instanceof AntiCaptchaError ) && (e.code === ErrorCodes.ERROR_IP_BLOCKED ) ) {
            // do something...
        }
    }
}
```